### PR TITLE
Created MessageBoard class and tests

### DIFF
--- a/train.rb
+++ b/train.rb
@@ -1,15 +1,27 @@
 class Conductor
 
-	attr_reader :engineer
+	attr_reader :message_board
 
-	def initialize(engineer)
-		@engineer = engineer
+	def initialize(message_board)
+		@message_board = message_board
 	end
 
 	def see_danger_coming!
-		engineer.slow_down!
+		message_board.slow_down!
 	end
 end
 
 class Engineer
+	attr_reader :message_board
+
+	def initialize(message_board)
+		@message_board = message_board
+	end
+
+	def slow_down
+		message_board.confirm_slow_down
+	end
+end
+
+class MessageBoard
 end

--- a/train_spec.rb
+++ b/train_spec.rb
@@ -2,12 +2,22 @@ require 'rspec'
 require './train'
 describe Conductor do
 
-	let(:engineer) { Engineer.new }
-	let(:conductor) { Conductor.new(engineer)}
+	let(:conductor) { Conductor.new(message_board) }
+	let(:message_board) { mock }
 
-	it "should tell the engineer to slow down" do
-		engineer.should_receive(:slow_down!)
+	it "should tell the message board to slow down" do
+		message_board.should_receive(:slow_down!)
 		conductor.see_danger_coming!
 	end
 	
+end
+
+describe Engineer do
+	let(:engineer) { Engineer.new(message_board) }
+	let(:message_board) { mock }
+
+	it "should send message board a slow down confirmation" do
+		message_board.should_receive(:confirm_slow_down)
+		engineer.slow_down
+	end
 end


### PR DESCRIPTION
Question: 
I have the latest version of RSpec installed and when I ran tests, it gave me the warning

```
DEPRECATION: mock is deprecated. Use double instead.
```

Other sources said 'mock' was just an alias for 'double' anyways but I couldn't figure out how to use 'double' correctly. I suspect it has a slightly different function than mock as well. Can you give any guidance on that?
